### PR TITLE
Fix --trusted option

### DIFF
--- a/spotseeker_server/management/commands/create_consumer.py
+++ b/spotseeker_server/management/commands/create_consumer.py
@@ -40,8 +40,8 @@ class Command(BaseCommand):
                     dest='trusted',
                     action='store_true',
                     default=False,
-                    help="Set to 'yes' if you want this client to be "
-                         "trusted to act for others"),
+                    help="Makes this consumer trusted "
+                    "(Adds a TrustedOAuthClient for it)"),
 
         make_option('--silent',
                     dest='silent',

--- a/spotseeker_server/management/commands/create_consumer.py
+++ b/spotseeker_server/management/commands/create_consumer.py
@@ -38,6 +38,7 @@ class Command(BaseCommand):
 
         make_option('--trusted',
                     dest='trusted',
+                    action='store_true',
                     default=False,
                     help="Set to 'yes' if you want this client to be "
                          "trusted to act for others"),
@@ -65,7 +66,7 @@ class Command(BaseCommand):
                                            key=key,
                                            secret=secret)
 
-        if options['trusted'] and options['trusted'] == 'yes':
+        if options['trusted']:
             trusted = TrustedOAuthClient.objects.create(consumer=consumer,
                                                         is_trusted=1)
 


### PR DESCRIPTION
Makes --trusted option work like 'create_consumer --trusted' rather than requiring 'create_consumer --trusted yes'