### PR TITLE
Working/extended info with dates

### DIFF
--- a/spotseeker_server/migrations/0021_auto__add_field_spotextendedinfo_valid_on__add_field_spotextendedinfo_.py
+++ b/spotseeker_server/migrations/0021_auto__add_field_spotextendedinfo_valid_on__add_field_spotextendedinfo_.py
@@ -1,0 +1,195 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Removing unique constraint on 'SpotExtendedInfo', fields ['spot', 'key']
+        db.delete_unique('spotseeker_server_spotextendedinfo', ['spot_id', 'key'])
+
+        # Adding field 'SpotExtendedInfo.valid_on'
+        db.add_column('spotseeker_server_spotextendedinfo', 'valid_on',
+                      self.gf('django.db.models.fields.DateTimeField')(null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'SpotExtendedInfo.valid_until'
+        db.add_column('spotseeker_server_spotextendedinfo', 'valid_until',
+                      self.gf('django.db.models.fields.DateTimeField')(null=True, blank=True),
+                      keep_default=False)
+
+        # Adding unique constraint on 'SpotExtendedInfo', fields ['spot', 'key', 'valid_on', 'valid_until']
+        db.create_unique('spotseeker_server_spotextendedinfo', ['spot_id', 'key', 'valid_on', 'valid_until'])
+
+
+    def backwards(self, orm):
+        # Removing unique constraint on 'SpotExtendedInfo', fields ['spot', 'key', 'valid_on', 'valid_until']
+        db.delete_unique('spotseeker_server_spotextendedinfo', ['spot_id', 'key', 'valid_on', 'valid_until'])
+
+        # Deleting field 'SpotExtendedInfo.valid_on'
+        db.delete_column('spotseeker_server_spotextendedinfo', 'valid_on')
+
+        # Deleting field 'SpotExtendedInfo.valid_until'
+        db.delete_column('spotseeker_server_spotextendedinfo', 'valid_until')
+
+        # Adding unique constraint on 'SpotExtendedInfo', fields ['spot', 'key']
+        db.create_unique('spotseeker_server_spotextendedinfo', ['spot_id', 'key'])
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'oauth_provider.consumer': {
+            'Meta': {'object_name': 'Consumer'},
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'secret': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'status': ('django.db.models.fields.SmallIntegerField', [], {'default': '1'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'xauth_allowed': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        'spotseeker_server.favoritespot': {
+            'Meta': {'object_name': 'FavoriteSpot'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'spot': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['spotseeker_server.Spot']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'spotseeker_server.sharedspace': {
+            'Meta': {'object_name': 'SharedSpace'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'sender': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'space': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['spotseeker_server.Spot']"}),
+            'user': ('django.db.models.fields.CharField', [], {'max_length': '16'})
+        },
+        'spotseeker_server.sharedspacerecipient': {
+            'Meta': {'object_name': 'SharedSpaceRecipient'},
+            'date_first_viewed': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'date_shared': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'hash_key': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'recipient': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'shared_count': ('django.db.models.fields.IntegerField', [], {}),
+            'shared_space': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['spotseeker_server.SharedSpace']"}),
+            'user': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'viewed_count': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'spotseeker_server.spacereview': {
+            'Meta': {'object_name': 'SpaceReview'},
+            'date_published': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'date_submitted': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'original_review': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '1000'}),
+            'published_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'published_by'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'rating': ('django.db.models.fields.IntegerField', [], {}),
+            'review': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '1000'}),
+            'reviewer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'reviewer'", 'to': "orm['auth.User']"}),
+            'space': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['spotseeker_server.Spot']"})
+        },
+        'spotseeker_server.spot': {
+            'Meta': {'object_name': 'Spot'},
+            'building_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'capacity': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'display_access_restrictions': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'etag': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'external_id': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '100', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'floor': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'height_from_sea_level': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '11', 'decimal_places': '8', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'auto_now_add': 'True', 'blank': 'True'}),
+            'latitude': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '11', 'decimal_places': '8'}),
+            'longitude': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '11', 'decimal_places': '8'}),
+            'manager': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'organization': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'room_number': ('django.db.models.fields.CharField', [], {'max_length': '25', 'blank': 'True'}),
+            'spottypes': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'spots'", 'to': "orm['spotseeker_server.SpotType']", 'max_length': '50', 'blank': 'True', 'symmetrical': 'False', 'null': 'True'})
+        },
+        'spotseeker_server.spotavailablehours': {
+            'Meta': {'object_name': 'SpotAvailableHours'},
+            'day': ('django.db.models.fields.CharField', [], {'max_length': '3'}),
+            'end_time': ('django.db.models.fields.TimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'spot': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['spotseeker_server.Spot']"}),
+            'start_time': ('django.db.models.fields.TimeField', [], {})
+        },
+        'spotseeker_server.spotextendedinfo': {
+            'Meta': {'unique_together': "(('spot', 'key', 'valid_on', 'valid_until'),)", 'object_name': 'SpotExtendedInfo'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'spot': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['spotseeker_server.Spot']"}),
+            'valid_on': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'valid_until': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '350'})
+        },
+        'spotseeker_server.spotimage': {
+            'Meta': {'object_name': 'SpotImage'},
+            'content_type': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'display_index': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'etag': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'height': ('django.db.models.fields.IntegerField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'modification_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'spot': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['spotseeker_server.Spot']"}),
+            'upload_application': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'upload_user': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'width': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'spotseeker_server.spottype': {
+            'Meta': {'object_name': 'SpotType'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'max_length': '50'})
+        },
+        'spotseeker_server.trustedoauthclient': {
+            'Meta': {'object_name': 'TrustedOAuthClient'},
+            'bypasses_user_authorization': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'consumer': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['oauth_provider.Consumer']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_trusted': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        }
+    }
+
+    complete_apps = ['spotseeker_server']

--- a/spotseeker_server/migrations/0022_auto__add_index_spotextendedinfo_valid_until__add_index_spotextendedin.py
+++ b/spotseeker_server/migrations/0022_auto__add_index_spotextendedinfo_valid_until__add_index_spotextendedin.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding index on 'SpotExtendedInfo', fields ['valid_until']
+        db.create_index('spotseeker_server_spotextendedinfo', ['valid_until'])
+
+        # Adding index on 'SpotExtendedInfo', fields ['valid_on']
+        db.create_index('spotseeker_server_spotextendedinfo', ['valid_on'])
+
+
+    def backwards(self, orm):
+        # Removing index on 'SpotExtendedInfo', fields ['valid_on']
+        db.delete_index('spotseeker_server_spotextendedinfo', ['valid_on'])
+
+        # Removing index on 'SpotExtendedInfo', fields ['valid_until']
+        db.delete_index('spotseeker_server_spotextendedinfo', ['valid_until'])
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'oauth_provider.consumer': {
+            'Meta': {'object_name': 'Consumer'},
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'secret': ('django.db.models.fields.CharField', [], {'max_length': '16', 'blank': 'True'}),
+            'status': ('django.db.models.fields.SmallIntegerField', [], {'default': '1'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'xauth_allowed': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        'spotseeker_server.favoritespot': {
+            'Meta': {'object_name': 'FavoriteSpot'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'spot': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['spotseeker_server.Spot']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'spotseeker_server.sharedspace': {
+            'Meta': {'object_name': 'SharedSpace'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'sender': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'space': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['spotseeker_server.Spot']"}),
+            'user': ('django.db.models.fields.CharField', [], {'max_length': '16'})
+        },
+        'spotseeker_server.sharedspacerecipient': {
+            'Meta': {'object_name': 'SharedSpaceRecipient'},
+            'date_first_viewed': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'date_shared': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'hash_key': ('django.db.models.fields.CharField', [], {'max_length': '32'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'recipient': ('django.db.models.fields.CharField', [], {'max_length': '256'}),
+            'shared_count': ('django.db.models.fields.IntegerField', [], {}),
+            'shared_space': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['spotseeker_server.SharedSpace']"}),
+            'user': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '16', 'null': 'True', 'blank': 'True'}),
+            'viewed_count': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'spotseeker_server.spacereview': {
+            'Meta': {'object_name': 'SpaceReview'},
+            'date_published': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'date_submitted': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_published': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'original_review': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '1000'}),
+            'published_by': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'published_by'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'rating': ('django.db.models.fields.IntegerField', [], {}),
+            'review': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '1000'}),
+            'reviewer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'reviewer'", 'to': "orm['auth.User']"}),
+            'space': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['spotseeker_server.Spot']"})
+        },
+        'spotseeker_server.spot': {
+            'Meta': {'object_name': 'Spot'},
+            'building_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'capacity': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'display_access_restrictions': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'etag': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'external_id': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '100', 'unique': 'True', 'null': 'True', 'blank': 'True'}),
+            'floor': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'height_from_sea_level': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '11', 'decimal_places': '8', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'auto_now_add': 'True', 'blank': 'True'}),
+            'latitude': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '11', 'decimal_places': '8'}),
+            'longitude': ('django.db.models.fields.DecimalField', [], {'null': 'True', 'max_digits': '11', 'decimal_places': '8'}),
+            'manager': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'blank': 'True'}),
+            'organization': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'room_number': ('django.db.models.fields.CharField', [], {'max_length': '25', 'blank': 'True'}),
+            'spottypes': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'spots'", 'to': "orm['spotseeker_server.SpotType']", 'max_length': '50', 'blank': 'True', 'symmetrical': 'False', 'null': 'True'})
+        },
+        'spotseeker_server.spotavailablehours': {
+            'Meta': {'object_name': 'SpotAvailableHours'},
+            'day': ('django.db.models.fields.CharField', [], {'max_length': '3'}),
+            'end_time': ('django.db.models.fields.TimeField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'spot': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['spotseeker_server.Spot']"}),
+            'start_time': ('django.db.models.fields.TimeField', [], {})
+        },
+        'spotseeker_server.spotextendedinfo': {
+            'Meta': {'unique_together': "(('spot', 'key', 'valid_on', 'valid_until'),)", 'object_name': 'SpotExtendedInfo'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'spot': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['spotseeker_server.Spot']"}),
+            'valid_on': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'valid_until': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'value': ('django.db.models.fields.CharField', [], {'max_length': '350'})
+        },
+        'spotseeker_server.spotimage': {
+            'Meta': {'object_name': 'SpotImage'},
+            'content_type': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'creation_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '200', 'blank': 'True'}),
+            'display_index': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'etag': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'height': ('django.db.models.fields.IntegerField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100'}),
+            'modification_date': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'spot': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['spotseeker_server.Spot']"}),
+            'upload_application': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'upload_user': ('django.db.models.fields.CharField', [], {'max_length': '40'}),
+            'width': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'spotseeker_server.spottype': {
+            'Meta': {'object_name': 'SpotType'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'max_length': '50'})
+        },
+        'spotseeker_server.trustedoauthclient': {
+            'Meta': {'object_name': 'TrustedOAuthClient'},
+            'bypasses_user_authorization': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'consumer': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['oauth_provider.Consumer']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_trusted': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        }
+    }
+
+    complete_apps = ['spotseeker_server']

--- a/spotseeker_server/models.py
+++ b/spotseeker_server/models.py
@@ -383,10 +383,8 @@ class SpotExtendedInfo(models.Model):
                     return 1
 
             if _is_full_window(a):
-                full_compare = _fully_defined_window_comparison(a, b)
+                return _fully_defined_window_comparison(a, b)
 
-                if full_compare:
-                    return full_compare
             if _is_full_window(b):
                 return -1
 

--- a/spotseeker_server/models.py
+++ b/spotseeker_server/models.py
@@ -116,7 +116,6 @@ class Spot(models.Model):
 
         return info
 
-
     def json_data_structure(self):
         extended_info = {}
         info = self.current_extended_info()

--- a/spotseeker_server/models.py
+++ b/spotseeker_server/models.py
@@ -339,6 +339,11 @@ class SpotExtendedInfo(models.Model):
         self.spot.save()  # Update the last_modified on the spot
         super(SpotExtendedInfo, self).save(*args, **kwargs)
 
+    def generate_key(self):
+        return "%s_%s_%s" % (self.key,
+                             str(self.valid_on),
+                             str(self.valid_until))
+
     @staticmethod
     def sort_method(a, b):
         """

--- a/spotseeker_server/models.py
+++ b/spotseeker_server/models.py
@@ -324,8 +324,8 @@ class SpotExtendedInfo(models.Model):
     key = models.CharField(max_length=50)
     value = models.CharField(max_length=350)
     spot = models.ForeignKey(Spot)
-    valid_on = models.DateTimeField(null=True, blank=True)
-    valid_until = models.DateTimeField(null=True, blank=True)
+    valid_on = models.DateTimeField(null=True, blank=True, db_index=True)
+    valid_until = models.DateTimeField(null=True, blank=True, db_index=True)
 
     class Meta:
         verbose_name_plural = "Spot extended info"

--- a/spotseeker_server/models.py
+++ b/spotseeker_server/models.py
@@ -102,9 +102,10 @@ class Spot(models.Model):
     def current_extended_info(self):
         now = timezone.now()
         current = ((Q(valid_on__lte=now) | Q(valid_on__isnull=True)) &
-                  (Q(valid_until__gte=now) | Q(valid_until__isnull=True)))
+                   (Q(valid_until__gte=now) | Q(valid_until__isnull=True)))
 
-        info = SpotExtendedInfo.objects.filter(spot=self).filter(current)
+        info = list(SpotExtendedInfo.objects.filter(spot=self).filter(current))
+        info.sort(SpotExtendedInfo.sort_method)
 
         return info
 
@@ -112,7 +113,8 @@ class Spot(models.Model):
         now = timezone.now()
         future = (Q(valid_on__gte=now) | Q(valid_until__gte=now))
 
-        info = SpotExtendedInfo.objects.filter(spot=self).filter(future)
+        info = list(SpotExtendedInfo.objects.filter(spot=self).filter(future))
+        info.sort(SpotExtendedInfo.sort_method)
 
         return info
 
@@ -336,6 +338,96 @@ class SpotExtendedInfo(models.Model):
         self.full_clean()
         self.spot.save()  # Update the last_modified on the spot
         super(SpotExtendedInfo, self).save(*args, **kwargs)
+
+    @staticmethod
+    def sort_method(a, b):
+        """
+        This will sort by least to most specific, then alphabetically by
+        key.  The idea is that if you have a list of extended info objects
+        with the same key, the last one is the most useful.
+        """
+
+        def sort_by_window(a, b):
+            if a.valid_on and a.valid_until:
+                if b.valid_on and b.valid_until:
+                    # If both are fully defined, the nearest end date should
+                    # by the more valued entry
+                    if b.valid_until < a.valid_until:
+                        return -1
+                    elif b.valid_until > a.valid_until:
+                        return 1
+
+                    # If the end dates are the same, the one with the most
+                    # recent start date is preferred
+                    if b.valid_on > a.valid_on:
+                        return -1
+                    elif b.valid_on < a.valid_on:
+                        return 1
+                    return 0
+                else:
+                    return 1
+            if b.valid_on and b.valid_until:
+                return -1
+
+            # Both are missing at least one part of the window:
+            # Test to see if one (or both) of them is totally undefined
+            if not a.valid_on and not a.valid_until:
+                if b.valid_on or b.valid_until:
+                    return -1
+                return 0
+            if not b.valid_on and not b.valid_until:
+                return 1
+
+            # if one has a defined end, and the other doesn't, that's preferred
+            if a.valid_until and not b.valid_until:
+                return 1
+
+            if b.valid_until and not a.valid_until:
+                return -1
+
+            # Now just choose the closest of whichever side is defined
+            if a.valid_until and b.valid_until:
+                if a.valid_until < b.valid_until:
+                    return 1
+                if b.valid_until < a.valid_until:
+                    return -1
+
+            if a.valid_on and b.valid_on:
+                if a.valid_on < b.valid_on:
+                    return -1
+                if b.valid_on < a.valid_on:
+                    return 1
+
+        def sort_by_values(a, b):
+            # Sort by key, or if those are the same, by value
+            ak = a.key.lower()
+            bk = b.key.lower()
+            if ak == bk:
+                av = a.value.lower()
+                bv = b.value.lower()
+
+                if av < bv:
+                    return -1
+                elif av > bv:
+                    return 1
+
+                return 0
+
+            elif ak < bk:
+                return -1
+            else:
+                return 1
+
+        by_window = sort_by_window(a, b)
+
+        if by_window:
+            return by_window
+
+        by_value = sort_by_values(a, b)
+        if by_value:
+            return by_value
+
+        return 0
 
 
 class SpotImage(models.Model):

--- a/spotseeker_server/test/future/future_get.py
+++ b/spotseeker_server/test/future/future_get.py
@@ -70,7 +70,6 @@ class FutureGETTest(TestCase):
 
         self.spot2 = spot2
 
-
         spot3 = Spot.objects.create(name="Testing spot with future",
                                     latitude=23,
                                     longitude=45)
@@ -118,7 +117,6 @@ class FutureGETTest(TestCase):
             valid_on=yesterday,
             spot=spot5)
 
-
         SpotExtendedInfo.objects.create(
             key="p_f",
             value="ok3",
@@ -132,7 +130,6 @@ class FutureGETTest(TestCase):
             spot=spot5)
 
         self.spot5 = spot5
-
 
     def test_spot_past_extended_info(self):
         url = "/api/v1/spot/%s" % self.spot1.pk
@@ -165,11 +162,13 @@ class FutureGETTest(TestCase):
         self.assertEqual(returned_spot, self.spot3)
 
         self.assertEquals(len(spot_dict['future_extended_info']), 1)
-        self.assertEquals(spot_dict['future_extended_info'][0]['has_whiteboards'], 'true')
-        self.assertEquals(spot_dict['future_extended_info'][0]['valid_on'], self.tomorrow.isoformat())
-        self.assertEquals(spot_dict['future_extended_info'][0]['valid_until'], self.next_week.isoformat())
+        whiteboards = spot_dict['future_extended_info'][0]['has_whiteboards']
+        self.assertEquals(whiteboards, 'true')
+        self.assertEquals(spot_dict['future_extended_info'][0]['valid_on'],
+                          self.tomorrow.isoformat())
+        self.assertEquals(spot_dict['future_extended_info'][0]['valid_until'],
+                          self.next_week.isoformat())
         self.assertEquals(spot_dict['extended_info'], {})
-
 
     def test_spot_future_plus_current_extended_info(self):
         url = "/api/v1/spot/%s" % self.spot4.pk
@@ -180,11 +179,13 @@ class FutureGETTest(TestCase):
         self.assertEqual(returned_spot, self.spot4)
 
         self.assertEquals(len(spot_dict['future_extended_info']), 1)
-        self.assertEquals(spot_dict['future_extended_info'][0]['has_whiteboards'], 'true')
-        self.assertEquals(spot_dict['future_extended_info'][0]['valid_on'], self.tomorrow.isoformat())
-        self.assertEquals(spot_dict['future_extended_info'][0]['valid_until'], self.next_week.isoformat())
+        whiteboards = spot_dict['future_extended_info'][0]['has_whiteboards']
+        self.assertEquals(whiteboards, 'true')
+        self.assertEquals(spot_dict['future_extended_info'][0]['valid_on'],
+                          self.tomorrow.isoformat())
+        self.assertEquals(spot_dict['future_extended_info'][0]['valid_until'],
+                          self.next_week.isoformat())
         self.assertEquals(spot_dict['extended_info']['has_whiteboards'], 'no')
-
 
     def test_spot_multiple_ways_of_now(self):
         url = "/api/v1/spot/%s" % self.spot5.pk
@@ -200,7 +201,6 @@ class FutureGETTest(TestCase):
         self.assertEquals(spot_dict['extended_info']['p_x'], 'ok4')
 
         self.assertEquals(len(spot_dict['future_extended_info']), 2)
-
 
     def tearDown(self):
         self.spot1.delete()

--- a/spotseeker_server/test/future/future_get.py
+++ b/spotseeker_server/test/future/future_get.py
@@ -1,0 +1,210 @@
+""" Copyright 2016 UW Information Technology, University of Washington
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+from django.test import TestCase
+from django.conf import settings
+from django.test.client import Client
+from spotseeker_server.models import Spot, SpotExtendedInfo
+import simplejson as json
+from django.test.utils import override_settings
+from mock import patch
+from datetime import datetime, timedelta
+from django.utils import timezone
+
+
+@override_settings(
+    SPOTSEEKER_AUTH_MODULE='spotseeker_server.auth.all_ok',
+    SPOTSEEKER_SPOT_FORM='spotseeker_server.default_forms.spot.'
+                         'DefaultSpotForm')
+class FutureGETTest(TestCase):
+    def setUp(self):
+        now = timezone.now()
+        last_week = now - timedelta(days=7)
+        yesterday = now - timedelta(days=1)
+
+        next_week = now + timedelta(days=7)
+        tomorrow = now + timedelta(days=1)
+
+        self.now = now
+        self.last_week = last_week
+        self.yesterday = yesterday
+        self.next_week = next_week
+        self.tomorrow = tomorrow
+
+        spot1 = Spot.objects.create(name="Testing spot with only past",
+                                    latitude=23,
+                                    longitude=45)
+
+        SpotExtendedInfo.objects.create(
+            key="has_whiteboards",
+            value="true",
+            valid_on=last_week,
+            valid_until=yesterday,
+            spot=spot1)
+
+        self.spot1 = spot1
+
+        spot2 = Spot.objects.create(name="Testing spot with past + current",
+                                    latitude=23,
+                                    longitude=45)
+
+        SpotExtendedInfo.objects.create(
+            key="has_whiteboards",
+            value="true",
+            valid_on=last_week,
+            valid_until=yesterday,
+            spot=spot2)
+
+        SpotExtendedInfo.objects.create(
+            key="has_whiteboards",
+            value="no",
+            spot=spot2)
+
+        self.spot2 = spot2
+
+
+        spot3 = Spot.objects.create(name="Testing spot with future",
+                                    latitude=23,
+                                    longitude=45)
+
+        SpotExtendedInfo.objects.create(
+            key="has_whiteboards",
+            value="true",
+            valid_on=tomorrow,
+            valid_until=next_week,
+            spot=spot3)
+
+        self.spot3 = spot3
+
+        spot4 = Spot.objects.create(name="Testing spot with future + current",
+                                    latitude=23,
+                                    longitude=45)
+
+        SpotExtendedInfo.objects.create(
+            key="has_whiteboards",
+            value="true",
+            valid_on=tomorrow,
+            valid_until=next_week,
+            spot=spot4)
+
+        SpotExtendedInfo.objects.create(
+            key="has_whiteboards",
+            value="no",
+            spot=spot4)
+
+        self.spot4 = spot4
+
+        spot5 = Spot.objects.create(name="Testing spot with variations",
+                                    latitude=23,
+                                    longitude=45)
+
+        SpotExtendedInfo.objects.create(
+            key="x_f",
+            value="ok2",
+            valid_until=tomorrow,
+            spot=spot5)
+
+        SpotExtendedInfo.objects.create(
+            key="p_x",
+            value="ok4",
+            valid_on=yesterday,
+            spot=spot5)
+
+
+        SpotExtendedInfo.objects.create(
+            key="p_f",
+            value="ok3",
+            valid_on=yesterday,
+            valid_until=tomorrow,
+            spot=spot5)
+
+        SpotExtendedInfo.objects.create(
+            key="x_x",
+            value="ok1",
+            spot=spot5)
+
+        self.spot5 = spot5
+
+
+    def test_spot_past_extended_info(self):
+        url = "/api/v1/spot/%s" % self.spot1.pk
+        response = self.client.get(url)
+        spot_dict = json.loads(response.content)
+        returned_spot = Spot.objects.get(pk=spot_dict['id'])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(returned_spot, self.spot1)
+
+        self.assertEquals(spot_dict['future_extended_info'], [])
+        self.assertEquals(spot_dict['extended_info'], {})
+
+    def test_spot_past_plus_current(self):
+        url = "/api/v1/spot/%s" % self.spot2.pk
+        response = self.client.get(url)
+        spot_dict = json.loads(response.content)
+        returned_spot = Spot.objects.get(pk=spot_dict['id'])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(returned_spot, self.spot2)
+
+        self.assertEquals(spot_dict['future_extended_info'], [])
+        self.assertEquals(spot_dict['extended_info']['has_whiteboards'], 'no')
+
+    def test_spot_future_extended_info(self):
+        url = "/api/v1/spot/%s" % self.spot3.pk
+        response = self.client.get(url)
+        spot_dict = json.loads(response.content)
+        returned_spot = Spot.objects.get(pk=spot_dict['id'])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(returned_spot, self.spot3)
+
+        self.assertEquals(len(spot_dict['future_extended_info']), 1)
+        self.assertEquals(spot_dict['future_extended_info'][0]['has_whiteboards'], 'true')
+        self.assertEquals(spot_dict['future_extended_info'][0]['valid_on'], self.tomorrow.isoformat())
+        self.assertEquals(spot_dict['future_extended_info'][0]['valid_until'], self.next_week.isoformat())
+        self.assertEquals(spot_dict['extended_info'], {})
+
+
+    def test_spot_future_plus_current_extended_info(self):
+        url = "/api/v1/spot/%s" % self.spot4.pk
+        response = self.client.get(url)
+        spot_dict = json.loads(response.content)
+        returned_spot = Spot.objects.get(pk=spot_dict['id'])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(returned_spot, self.spot4)
+
+        self.assertEquals(len(spot_dict['future_extended_info']), 1)
+        self.assertEquals(spot_dict['future_extended_info'][0]['has_whiteboards'], 'true')
+        self.assertEquals(spot_dict['future_extended_info'][0]['valid_on'], self.tomorrow.isoformat())
+        self.assertEquals(spot_dict['future_extended_info'][0]['valid_until'], self.next_week.isoformat())
+        self.assertEquals(spot_dict['extended_info']['has_whiteboards'], 'no')
+
+
+    def test_spot_multiple_ways_of_now(self):
+        url = "/api/v1/spot/%s" % self.spot5.pk
+        response = self.client.get(url)
+        spot_dict = json.loads(response.content)
+        returned_spot = Spot.objects.get(pk=spot_dict['id'])
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(returned_spot, self.spot5)
+
+        self.assertEquals(spot_dict['extended_info']['x_x'], 'ok1')
+        self.assertEquals(spot_dict['extended_info']['x_f'], 'ok2')
+        self.assertEquals(spot_dict['extended_info']['p_f'], 'ok3')
+        self.assertEquals(spot_dict['extended_info']['p_x'], 'ok4')
+
+        self.assertEquals(len(spot_dict['future_extended_info']), 2)
+
+
+    def tearDown(self):
+        self.spot1.delete()
+        self.spot2.delete()
+        self.spot3.delete()
+        self.spot4.delete()
+        self.spot5.delete()

--- a/spotseeker_server/test/future/future_put.py
+++ b/spotseeker_server/test/future/future_put.py
@@ -1,0 +1,294 @@
+""" Copyright 2016 UW Information Technology, University of Washington
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+from django.test import TestCase
+from django.conf import settings
+from django.test.client import Client
+from spotseeker_server.models import Spot, SpotExtendedInfo
+import simplejson as json
+from django.test.utils import override_settings
+from mock import patch
+from datetime import datetime, timedelta
+from django.utils import timezone
+
+
+@override_settings(
+    SPOTSEEKER_AUTH_MODULE='spotseeker_server.auth.all_ok',
+    SPOTSEEKER_SPOT_FORM='spotseeker_server.default_forms.spot.'
+                         'DefaultSpotForm')
+@override_settings(
+    SPOTSEEKER_SPOTEXTENDEDINFO_FORM='spotseeker_server.default_forms.spot.'
+                                     'DefaultSpotExtendedInfoForm')
+@override_settings(SPOTSEEKER_AUTH_ADMINS=('demo_user',))
+class FuturePUTTest(TestCase):
+    """ Tests updating future Spot Extended information via PUT.
+    """
+
+    def setUp(self):
+        spot = Spot.objects.create(name="This is for testing future PUT")
+        spot.save()
+        self.spot = spot
+
+        url = '/api/v1/spot/{0}'.format(self.spot.pk)
+        self.url = url
+
+        now = timezone.now()
+        last_week = now - timedelta(days=7)
+        yesterday = now - timedelta(days=1)
+
+        next_week = now + timedelta(days=7)
+        tomorrow = now + timedelta(days=1)
+
+        self.now = now
+        self.last_week = last_week
+        self.yesterday = yesterday
+        self.next_week = next_week
+        self.tomorrow = tomorrow
+
+    def test_future_without_dates(self):
+        c = Client()
+
+        response = c.get(self.url)
+        etag = response["ETag"]
+        data = {"name": self.spot.name,
+                "location": {"latitude": 55, "longitude": 30},
+                "future_extended_info": [
+                    {"future_key1": "future_value1"}
+                 ]
+                }
+        response = c.put(self.url,
+                         json.dumps(data),
+                         content_type="application/json",
+                         If_Match=etag)
+
+        response = c.get(self.url)
+        data = json.loads(response.content)
+        self.assertEquals(data["extended_info"]["future_key1"],
+                          "future_value1")
+
+    def test_future_with_start(self):
+        c = Client()
+
+        response = c.get(self.url)
+        etag = response["ETag"]
+        data = {"name": self.spot.name,
+                "location": {"latitude": 55, "longitude": 30},
+                "future_extended_info": [
+                    {"future_key1": "future_value1",
+                     "valid_on": self.tomorrow.isoformat()}
+                 ]
+                }
+        response = c.put(self.url,
+                         json.dumps(data),
+                         content_type="application/json",
+                         If_Match=etag)
+
+        response = c.get(self.url)
+        data = json.loads(response.content)
+        fei0 = data["future_extended_info"][0]
+        self.assertEquals(fei0["future_key1"], "future_value1")
+        self.assertEquals(fei0["valid_on"], self.tomorrow.isoformat())
+        self.assertEquals(fei0["valid_until"], None)
+
+    def test_future_with_end(self):
+        c = Client()
+
+        response = c.get(self.url)
+        etag = response["ETag"]
+        data = {"name": self.spot.name,
+                "location": {"latitude": 55, "longitude": 30},
+                "future_extended_info": [
+                    {"future_key1": "future_value1",
+                     "valid_until": self.tomorrow.isoformat()}
+                 ]
+                }
+        response = c.put(self.url,
+                         json.dumps(data),
+                         content_type="application/json",
+                         If_Match=etag)
+
+        response = c.get(self.url)
+        data = json.loads(response.content)
+        fei0 = data["future_extended_info"][0]
+        self.assertEquals(fei0["future_key1"], "future_value1")
+        self.assertEquals(fei0["valid_until"], self.tomorrow.isoformat())
+        self.assertEquals(fei0["valid_on"], None)
+
+    def test_future_with_full_range(self):
+        c = Client()
+
+        response = c.get(self.url)
+        etag = response["ETag"]
+        data = {"name": self.spot.name,
+                "location": {"latitude": 55, "longitude": 30},
+                "future_extended_info": [
+                    {"future_key1": "future_value1",
+                     "valid_on": self.tomorrow.isoformat(),
+                     "valid_until": self.next_week.isoformat()}
+                 ]
+                }
+        response = c.put(self.url,
+                         json.dumps(data),
+                         content_type="application/json",
+                         If_Match=etag)
+
+        response = c.get(self.url)
+        data = json.loads(response.content)
+        fei0 = data["future_extended_info"][0]
+        self.assertEquals(fei0["future_key1"], "future_value1")
+        self.assertEquals(fei0["valid_on"], self.tomorrow.isoformat())
+        self.assertEquals(fei0["valid_until"], self.next_week.isoformat())
+
+    def test_future_range_plus_default(self):
+        c = Client()
+
+        response = c.get(self.url)
+        etag = response["ETag"]
+        data = {"name": self.spot.name,
+                "location": {"latitude": 55, "longitude": 30},
+                "extended_info": {"future_key1": "all-time-value"},
+                "future_extended_info": [
+                    {"future_key1": "future_value2",
+                     "valid_on": self.tomorrow.isoformat(),
+                     "valid_until": self.next_week.isoformat()}
+                 ]
+                }
+        response = c.put(self.url,
+                         json.dumps(data),
+                         content_type="application/json",
+                         If_Match=etag)
+
+        response = c.get(self.url)
+        data = json.loads(response.content)
+        fei0 = data["future_extended_info"][0]
+        self.assertEquals(data["extended_info"]["future_key1"],
+                          "all-time-value")
+        self.assertEquals(fei0["future_key1"], "future_value2")
+        self.assertEquals(fei0["valid_on"], self.tomorrow.isoformat())
+        self.assertEquals(fei0["valid_until"], self.next_week.isoformat())
+
+    def test_future_range_plus_default_replacing(self):
+        c = Client()
+
+        response = c.get(self.url)
+        etag = response["ETag"]
+        data = {"name": self.spot.name,
+                "location": {"latitude": 55, "longitude": 30},
+                "extended_info": {"future_key1": "all-time-value-2"},
+                "future_extended_info": [
+                    {"future_key1": "future_value3",
+                     "valid_on": self.tomorrow.isoformat(),
+                     "valid_until": self.next_week.isoformat()}
+                 ]
+                }
+        response = c.put(self.url,
+                         json.dumps(data),
+                         content_type="application/json",
+                         If_Match=etag)
+
+        response = c.get(self.url)
+        data = json.loads(response.content)
+
+        fei0 = data["future_extended_info"][0]
+        self.assertEquals(data["extended_info"]["future_key1"],
+                          "all-time-value-2")
+        self.assertEquals(fei0["future_key1"], "future_value3")
+        self.assertEquals(fei0["valid_on"], self.tomorrow.isoformat())
+        self.assertEquals(fei0["valid_until"], self.next_week.isoformat())
+
+        response = c.get(self.url)
+        etag = response["ETag"]
+        data = {"name": self.spot.name,
+                "location": {"latitude": 55, "longitude": 30},
+                "extended_info": {"future_key1": "all-time-value-3"},
+                "future_extended_info": [
+                    {"future_key1": "future_value3",
+                     "valid_on": self.tomorrow.isoformat(),
+                     "valid_until": self.next_week.isoformat()}
+                 ]
+
+                }
+        response = c.put(self.url,
+                         json.dumps(data),
+                         content_type="application/json",
+                         If_Match=etag)
+
+        response = c.get(self.url)
+        etag = response["ETag"]
+        data = {"name": self.spot.name,
+                "location": {"latitude": 55, "longitude": 30},
+                "extended_info": {"future_key1": "all-time-value-3"},
+                "future_extended_info": [
+                    {"future_key1": "future_value4",
+                     "valid_on": self.tomorrow.isoformat(),
+                     "valid_until": self.next_week.isoformat()}
+                 ]
+                }
+        response = c.put(self.url,
+                         json.dumps(data),
+                         content_type="application/json",
+                         If_Match=etag)
+
+        response = c.get(self.url)
+        data = json.loads(response.content)
+        self.assertEquals(data["extended_info"]["future_key1"],
+                          "all-time-value-3")
+
+        fei0 = data["future_extended_info"][0]
+        self.assertEquals(fei0["future_key1"], "future_value4")
+        self.assertEquals(fei0["valid_on"], self.tomorrow.isoformat())
+        self.assertEquals(fei0["valid_until"], self.next_week.isoformat())
+
+    def test_future_range_plus_default_removal(self):
+        c = Client()
+
+        response = c.get(self.url)
+        etag = response["ETag"]
+        data = {"name": self.spot.name,
+                "location": {"latitude": 55, "longitude": 30},
+                "extended_info": {"future_key1": "all-time-value"},
+                "future_extended_info": [
+                    {"future_key1": "future_value2",
+                     "valid_on": self.tomorrow.isoformat(),
+                     "valid_until": self.next_week.isoformat()}
+                 ]
+                }
+        response = c.put(self.url,
+                         json.dumps(data),
+                         content_type="application/json",
+                         If_Match=etag)
+
+        response = c.get(self.url)
+        data = json.loads(response.content)
+        self.assertEquals(data["extended_info"]["future_key1"],
+                          "all-time-value")
+        fei0 = data["future_extended_info"][0]
+        self.assertEquals(fei0["future_key1"], "future_value2")
+        self.assertEquals(fei0["valid_on"], self.tomorrow.isoformat())
+        self.assertEquals(fei0["valid_until"], self.next_week.isoformat())
+
+        response = c.get(self.url)
+        etag = response["ETag"]
+        data = {"name": self.spot.name,
+                "location": {"latitude": 55, "longitude": 30},
+                }
+        response = c.put(self.url,
+                         json.dumps(data),
+                         content_type="application/json",
+                         If_Match=etag)
+
+        response = c.get(self.url)
+        data = json.loads(response.content)
+        self.assertEquals(data["extended_info"], {})
+        self.assertEquals(data["future_extended_info"], [])
+
+    def tearDown(self):
+        self.spot.delete()

--- a/spotseeker_server/test/models.py
+++ b/spotseeker_server/test/models.py
@@ -15,6 +15,8 @@
 
 from django.core.files import File
 from django.test import TestCase
+from datetime import datetime, timedelta
+from django.utils import timezone
 from os.path import abspath, dirname
 from spotseeker_server.models import *
 
@@ -57,3 +59,204 @@ class SpotModelToStringTests(TestCase):
 
         test_str = "{0}".format(gif)
         self.assertEqual(test_str, "This is the GIF test")
+
+
+class SpotExtendedInfoTests(TestCase):
+    def setUp(self):
+        s = Spot()
+
+        ei1 = SpotExtendedInfo()
+        ei1.spot = s
+        ei1.key = "k1"
+        ei1.value = "v1"
+        ei1.valid_on = None
+        ei1.valid_until = None
+
+        ei2 = SpotExtendedInfo()
+        ei2.spot = s
+        ei2.key = "k2"
+        ei2.value = "v2"
+        ei2.valid_on = None
+        ei2.valid_until = None
+
+        self.ei1 = ei1
+        self.ei2 = ei2
+
+    def test_none_v_left_def(self):
+        self.ei1.valid_on = None
+        self.ei1.valid_until = None
+
+        self.ei2.valid_on = timezone.now() - timedelta(days=1)
+        self.ei2.valid_until = None
+
+        ei_list = [self.ei2, self.ei1]
+        ei_list.sort(SpotExtendedInfo.sort_method)
+
+        self.assertEqual(ei_list[0].key, "k1")
+        self.assertEqual(ei_list[1].key, "k2")
+
+    def test_little_left_vs_big(self):
+        self.ei1.valid_on = timezone.now() - timedelta(days=2)
+        self.ei1.valid_until = None
+
+        self.ei2.valid_on = timezone.now() - timedelta(days=1)
+        self.ei2.valid_until = None
+
+        ei_list = [self.ei2, self.ei1]
+        ei_list.sort(SpotExtendedInfo.sort_method)
+
+        self.assertEqual(ei_list[0].key, "k1")
+        self.assertEqual(ei_list[1].key, "k2")
+
+    def test_left_v_right(self):
+        self.ei1.valid_on = timezone.now() - timedelta(days=2)
+        self.ei1.valid_until = None
+
+        self.ei2.valid_on = None
+        self.ei2.valid_until = timezone.now() + timedelta(days=1)
+
+        ei_list = [self.ei2, self.ei1]
+        ei_list.sort(SpotExtendedInfo.sort_method)
+
+        self.assertEqual(ei_list[0].key, "k1")
+        self.assertEqual(ei_list[1].key, "k2")
+
+    def test_little_v_big_right(self):
+        self.ei1.valid_on = None
+        self.ei1.valid_until = timezone.now() + timedelta(days=2)
+
+        self.ei2.valid_on = None
+        self.ei2.valid_until = timezone.now() + timedelta(days=1)
+
+        ei_list = [self.ei2, self.ei1]
+        ei_list.sort(SpotExtendedInfo.sort_method)
+
+        self.assertEqual(ei_list[0].key, "k1")
+        self.assertEqual(ei_list[1].key, "k2")
+
+    def test_right_vs_fully_defined(self):
+        self.ei1.valid_on = None
+        self.ei1.valid_until = timezone.now() + timedelta(days=1)
+
+        self.ei2.valid_on = timezone.now() - timedelta(days=1)
+        self.ei2.valid_until = timezone.now() + timedelta(days=2)
+
+        ei_list = [self.ei2, self.ei1]
+        ei_list.sort(SpotExtendedInfo.sort_method)
+
+        self.assertEqual(ei_list[0].key, "k1")
+        self.assertEqual(ei_list[1].key, "k2")
+
+    def test_big_vs_small_full_right_side(self):
+        self.ei1.valid_on = timezone.now() - timedelta(days=1)
+        self.ei1.valid_until = timezone.now() + timedelta(days=2)
+
+        self.ei2.valid_on = timezone.now() - timedelta(days=1)
+        self.ei2.valid_until = timezone.now() + timedelta(days=1)
+
+        ei_list = [self.ei2, self.ei1]
+        ei_list.sort(SpotExtendedInfo.sort_method)
+
+        self.assertEqual(ei_list[0].key, "k1")
+        self.assertEqual(ei_list[1].key, "k2")
+
+    def test_big_vs_small_full_left_side(self):
+        now = timezone.now()
+        self.ei1.valid_on = timezone.now() - timedelta(days=2)
+        self.ei1.valid_until = now + timedelta(days=1)
+
+        self.ei2.valid_on = timezone.now() - timedelta(days=1)
+        self.ei2.valid_until = now + timedelta(days=1)
+
+        ei_list = [self.ei2, self.ei1]
+        ei_list.sort(SpotExtendedInfo.sort_method)
+
+        self.assertEqual(ei_list[0].key, "k1")
+        self.assertEqual(ei_list[1].key, "k2")
+
+    def test_key_sort(self):
+        now = timezone.now()
+        self.ei1.valid_on = now - timedelta(days=1)
+        self.ei1.valid_until = now + timedelta(days=1)
+
+        self.ei2.valid_on = now - timedelta(days=1)
+        self.ei2.valid_until = now + timedelta(days=1)
+        self.ei2.key = "k2"
+
+        ei_list = [self.ei2, self.ei1]
+        ei_list.sort(SpotExtendedInfo.sort_method)
+
+        self.assertEqual(ei_list[0].value, "v1")
+        self.assertEqual(ei_list[1].value, "v2")
+
+    def test_value_sort(self):
+        now = timezone.now()
+        self.ei1.valid_on = now - timedelta(days=1)
+        self.ei1.valid_until = now + timedelta(days=1)
+
+        self.ei2.valid_on = now - timedelta(days=1)
+        self.ei2.key = "k1"
+        self.ei2.valid_until = now + timedelta(days=1)
+
+        ei_list = [self.ei2, self.ei1]
+        ei_list.sort(SpotExtendedInfo.sort_method)
+
+        self.assertEqual(ei_list[0].value, "v1")
+        self.assertEqual(ei_list[1].value, "v2")
+
+    def test_extended_info_sorting(self):
+        s = Spot()
+        now = timezone.now()
+
+        ei1 = SpotExtendedInfo()
+        ei1.spot = s
+        ei1.key = "k1"
+        ei1.value = "v1"
+        ei1.valid_on = None
+        ei1.valid_until = None
+
+        ei2 = SpotExtendedInfo()
+        ei2.spot = s
+        ei2.key = "k2"
+        ei2.value = "v2"
+        ei2.valid_on = now - timedelta(days=1)
+        ei2.valid_until = None
+
+        ei3 = SpotExtendedInfo()
+        ei3.spot = s
+        ei3.key = "k3"
+        ei3.value = "v3"
+        ei3.valid_on = None
+        ei3.valid_until = now + timedelta(days=1)
+
+        ei4 = SpotExtendedInfo()
+        ei4.spot = s
+        ei4.key = "k4"
+        ei4.value = "v4"
+        ei4.valid_on = now - timedelta(days=2)
+        ei4.valid_until = now + timedelta(days=2)
+
+        ei5 = SpotExtendedInfo()
+        ei5.spot = s
+        ei5.key = "k5"
+        ei5.value = "v5"
+        ei5.valid_on = now - timedelta(days=1)
+        ei5.valid_until = now + timedelta(days=1)
+
+        ei6 = SpotExtendedInfo()
+        ei6.spot = s
+        ei6.key = "k6"
+        ei6.value = "v6"
+        ei6.valid_on = now - timedelta(days=1)
+        ei6.valid_until = now + timedelta(days=1)
+
+        ei_list = [ei3, ei2, ei4, ei1, ei6, ei5]
+
+        ei_list.sort(SpotExtendedInfo.sort_method)
+
+        self.assertEquals(ei_list[0].key, "k1")
+        self.assertEquals(ei_list[1].key, "k2")
+        self.assertEquals(ei_list[2].key, "k3")
+        self.assertEquals(ei_list[3].key, "k4")
+        self.assertEquals(ei_list[4].key, "k5")
+        self.assertEquals(ei_list[5].key, "k6")

--- a/spotseeker_server/tests.py
+++ b/spotseeker_server/tests.py
@@ -69,3 +69,4 @@ from spotseeker_server.test.uw_spot.uw_search import UWSearchTest
 from spotseeker_server.test.favorites import FavoritesTest
 from spotseeker_server.test.share_space import ShareSpaceTest
 from spotseeker_server.test.reviews import ReviewsTest
+from spotseeker_server.test.future.future_get import FutureGETTest

--- a/spotseeker_server/tests.py
+++ b/spotseeker_server/tests.py
@@ -17,6 +17,7 @@ from django.utils import unittest
 
 from spotseeker_server.test.buildings import BuildingTest
 from spotseeker_server.test.models import SpotModelToStringTests
+from spotseeker_server.test.models import SpotExtendedInfoTests
 from spotseeker_server.test.spot_form import SpotFormTest
 from spotseeker_server.test.spot_model import SpotModelTest
 from spotseeker_server.test.spot_put import SpotPUTTest

--- a/spotseeker_server/tests.py
+++ b/spotseeker_server/tests.py
@@ -71,3 +71,4 @@ from spotseeker_server.test.favorites import FavoritesTest
 from spotseeker_server.test.share_space import ShareSpaceTest
 from spotseeker_server.test.reviews import ReviewsTest
 from spotseeker_server.test.future.future_get import FutureGETTest
+from spotseeker_server.test.future.future_put import FuturePUTTest


### PR DESCRIPTION
A method for handling extended info fields with date ranges.  This model doesn't create a distinct type of "future" extended info - it just makes it so extended info can have optional start and/or end dates where it's valid.  

Maintains backwards compatibility with the "extended_info" fields in the json, though for PUTs that can be bypassed by just adding a "future_extended_info" entry with no start or end date.

If this model is appealing, I would suggest doing the same for available hours.