### PR TITLE
Bug/scout 621

### DIFF
--- a/spotseeker_server/test/item/image_delete.py
+++ b/spotseeker_server/test/item/image_delete.py
@@ -13,7 +13,7 @@ from django.test import TestCase
 from django.conf import settings
 from django.test.client import Client
 from django.core.files import File
-from spotseeker_server.models import Item, ItemImage
+from spotseeker_server.models import Item, ItemImage, Spot
 from os.path import abspath, dirname, isfile
 from django.test.utils import override_settings
 from django.utils.unittest import skipUnless
@@ -30,7 +30,13 @@ class ItemImageDELETETest(TestCase):
     """ Tests DELETE of a ItemImage at /api/v1/item/<item id>/image/<image id>.
     """
     def setUp(self):
-        item = Item.objects.create(name="This is to test DELETEing images")
+        spot = Spot.objects.create(
+            name="This is a spot for testing DELETEing images")
+        spot.save()
+        item = Item.objects.create(
+            name="This is to test DELETEing images",
+            spot=spot    
+        )
         item.save()
         self.item = item
 

--- a/spotseeker_server/test/item/image_delete.py
+++ b/spotseeker_server/test/item/image_delete.py
@@ -35,7 +35,7 @@ class ItemImageDELETETest(TestCase):
         spot.save()
         item = Item.objects.create(
             name="This is to test DELETEing images",
-            spot=spot    
+            spot=spot
         )
         item.save()
         self.item = item

--- a/spotseeker_server/test/item/image_put.py
+++ b/spotseeker_server/test/item/image_put.py
@@ -14,7 +14,7 @@ from django.test import TestCase
 from django.conf import settings
 from django.test.client import Client, encode_multipart
 from django.core.files import File
-from spotseeker_server.models import Item, ItemImage
+from spotseeker_server.models import Item, ItemImage, Spot
 from os.path import abspath, dirname
 import os
 import random
@@ -37,8 +37,13 @@ class ItemImagePUTTest(TestCase):
     def setUp(self):
         self.TEMP_DIR = tempfile.mkdtemp()
         with self.settings(MEDIA_ROOT=self.TEMP_DIR):
+            spot = Spot.objects.create(
+                name="This is a spot fot testing PUTting images")
+            spot.save()
             item = Item.objects.create(
-                name="This is to test PUTtingimages")
+                name="This is to test PUTtingimages",
+                spot=spot
+            )
             item.save()
             self.item = item
 

--- a/spotseeker_server/test/item/image_thumbnail.py
+++ b/spotseeker_server/test/item/image_thumbnail.py
@@ -14,7 +14,7 @@ from django.test import TestCase
 from django.conf import settings
 from django.core.files import File
 from django.test.client import Client
-from spotseeker_server.models import Item, ItemImage
+from spotseeker_server.models import Item, ItemImage, Spot
 from cStringIO import StringIO
 from PIL import Image
 from os.path import abspath, dirname
@@ -35,8 +35,13 @@ class ItemImageThumbTest(TestCase):
             'django.core.cache.backends.dummy.DummyCache'
         )
         with patch.object(models, 'cache', dummy_cache):
+            spot = Spot.objects.create(
+                name="This spot is for testing thumbnailing images"
+            )
+            spot.save()
             item = Item.objects.create(
-                name="This is to test thumbnailing images"
+                name="This is to test thumbnailing images",
+                spot=spot
             )
             item.save()
             self.item = item

--- a/spotseeker_server/views/add_item_image.py
+++ b/spotseeker_server/views/add_item_image.py
@@ -56,6 +56,7 @@ class AddItemImageView(RESTDispatch):
                 args['display_index'] = 0
 
         image = item.itemimage_set.create(**args)
+        item.spot.save()
 
         response = HttpResponse(status=201)
         response["Location"] = image.rest_url()

--- a/spotseeker_server/views/item_image.py
+++ b/spotseeker_server/views/item_image.py
@@ -76,6 +76,7 @@ class ItemImageView(RESTDispatch):
         if "display_index" in request.META['files']:
             img.display_index = request.META['files']["display_index"]
         img.save()
+        item.spot.save()
 
         return self.GET(request, item_id, image_id)
 
@@ -90,5 +91,6 @@ class ItemImageView(RESTDispatch):
                                 404)
 
         img.delete()
+        item.spot.save()
 
         return HttpResponse(status=200)


### PR DESCRIPTION
The spot etag is now updated after item images are uploaded, so that the outdated cache is no longer served. Scout manager also needs to be updated to fix SCOUT-621. Unit tests were updated to accommodate the fact that item image modifications now require the item spot to exist. fixes: SCOUT-634